### PR TITLE
Don't specify a runtime identifier in YarnLanguageServer.csproj

### DIFF
--- a/LanguageServer/YarnLanguageServer.csproj
+++ b/LanguageServer/YarnLanguageServer.csproj
@@ -1,10 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
         <TargetFramework>net5.0</TargetFramework>
-        <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
         <LangVersion>latest</LangVersion>
         <StartupObject></StartupObject>
         <ApplicationIcon />

--- a/VSCodeExtension/src/extension.ts
+++ b/VSCodeExtension/src/extension.ts
@@ -21,7 +21,7 @@ export async function activate(context: ExtensionContext) {
     const languageServerExe = dotnetPath;
     const languageServerPath =
         isDebugMode() ?
-            path.resolve(context.asAbsolutePath("../LanguageServer/bin/Debug/net5.0/win7-x64/YarnLanguageServer.dll")) :
+            path.resolve(context.asAbsolutePath("../LanguageServer/bin/Debug/net5.0/YarnLanguageServer.dll")) :
             path.resolve(context.asAbsolutePath("/Server/YarnLanguageServer.dll"));
 
     let languageServerOptions: ServerOptions = {


### PR DESCRIPTION
Currently, the YarnLanguageServer.csproj project file is set to use the runtime identifier win7-x64. This means that the built binary can't be loaded on other platforms. 

There isn't anything specific to the Windows or x64 platform in this particular library, so removing this directive causes the compiler to produce a cross-platform .dll. This PR implements this change.

The .csproj files for the Visual Studio extensions are unaffected; only the language server library is modified in this change.

This PR I've also updated the VS Code extension to load the language server .dll from a new path (because removing the runtime identifier updates the path.)