### PR TITLE
Fixed issue of custom requests not receiving workspace data for Graph Editor

### DIFF
--- a/LanguageServer/src/Server/YarnLanguageServer.cs
+++ b/LanguageServer/src/Server/YarnLanguageServer.cs
@@ -87,7 +87,7 @@ namespace YarnLanguageServer
 
             // Register 'List Nodes' command
             options.OnExecuteCommand<Container<NodeInfo>>(
-                (commandParams) => ListNodesInDocumentAsync(workspace, commandParams),
+                (commandParams) => ListNodesInDocumentAsync(ref workspace, commandParams),
                 (_, _) => new ExecuteCommandRegistrationOptions
                 {
                     Commands = new[] { Commands.ListNodes },
@@ -96,7 +96,7 @@ namespace YarnLanguageServer
 
             // Register 'Add Nodes' command
             options.OnExecuteCommand<TextDocumentEdit>(
-                (commandParams) => AddNodeToDocumentAsync(workspace, commandParams),
+                (commandParams) => AddNodeToDocumentAsync(ref workspace, commandParams),
                 (_, _) => new ExecuteCommandRegistrationOptions
                 {
                     Commands = new[] { Commands.AddNode },
@@ -105,7 +105,7 @@ namespace YarnLanguageServer
 
             // Register 'Remove Node' command
             options.OnExecuteCommand<TextDocumentEdit>(
-                (commandParams) => RemoveNodeFromDocumentAsync(workspace, commandParams),
+                (commandParams) => RemoveNodeFromDocumentAsync(ref workspace, commandParams),
                 (_, _) => new ExecuteCommandRegistrationOptions
                 {
                     Commands = new[] { Commands.RemoveNode },
@@ -114,7 +114,7 @@ namespace YarnLanguageServer
 
             // Register 'Update Header' command
             options.OnExecuteCommand<TextDocumentEdit>(
-                (commandParams) => UpdateNodeHeaderAsync(workspace, commandParams),
+                (commandParams) => UpdateNodeHeaderAsync(ref workspace, commandParams),
                 (_, _) => new ExecuteCommandRegistrationOptions
                 {
                     Commands = new[] { Commands.UpdateNodeHeader },
@@ -123,7 +123,7 @@ namespace YarnLanguageServer
 
             // Register 'Compile' command
             options.OnExecuteCommand<CompilerOutput>(
-                (commandParams) => CompileWorkspace(workspace, commandParams),
+                (commandParams) => CompileWorkspace(ref workspace, commandParams),
                 (_, _) => new ExecuteCommandRegistrationOptions
                 {
                     Commands = new[] { Commands.Compile },
@@ -133,7 +133,7 @@ namespace YarnLanguageServer
             return options;
         }
 
-        private static Task<TextDocumentEdit> AddNodeToDocumentAsync(Workspace workspace, ExecuteCommandParams<TextDocumentEdit> commandParams)
+        private static Task<TextDocumentEdit> AddNodeToDocumentAsync(ref Workspace workspace, ExecuteCommandParams<TextDocumentEdit> commandParams)
         {
             var yarnDocumentUriString = commandParams.Arguments[0].ToString();
 
@@ -241,7 +241,7 @@ namespace YarnLanguageServer
             });
         }
 
-        private static Task<TextDocumentEdit> RemoveNodeFromDocumentAsync(Workspace workspace, ExecuteCommandParams<TextDocumentEdit> commandParams)
+        private static Task<TextDocumentEdit> RemoveNodeFromDocumentAsync(ref Workspace workspace, ExecuteCommandParams<TextDocumentEdit> commandParams)
         {
             var yarnDocumentUriString = commandParams.Arguments[0].ToString();
 
@@ -316,7 +316,7 @@ namespace YarnLanguageServer
             });
         }
 
-        private static Task<TextDocumentEdit> UpdateNodeHeaderAsync(Workspace workspace, ExecuteCommandParams<TextDocumentEdit> commandParams)
+        private static Task<TextDocumentEdit> UpdateNodeHeaderAsync(ref Workspace workspace, ExecuteCommandParams<TextDocumentEdit> commandParams)
         {
             var yarnDocumentUriString = commandParams.Arguments[0].ToString();
 
@@ -405,7 +405,7 @@ namespace YarnLanguageServer
             });
         }
 
-        private static Task<Container<NodeInfo>> ListNodesInDocumentAsync(Workspace workspace, ExecuteCommandParams<Container<NodeInfo>> commandParams)
+        private static Task<Container<NodeInfo>> ListNodesInDocumentAsync(ref Workspace workspace, ExecuteCommandParams<Container<NodeInfo>> commandParams)
         {
             var result = new List<NodeInfo>();
 
@@ -421,7 +421,7 @@ namespace YarnLanguageServer
             return Task.FromResult<Container<NodeInfo>>(result);
         }
 
-        private static Task<CompilerOutput> CompileWorkspace(Workspace workspace, ExecuteCommandParams<CompilerOutput> commandParams)
+        private static Task<CompilerOutput> CompileWorkspace(ref Workspace workspace, ExecuteCommandParams<CompilerOutput> commandParams)
         {
             var job = new Yarn.Compiler.CompilationJob
             {


### PR DESCRIPTION
It's an issue of pass by value vs. pass by reference. When the workspace is passed to the request, I think it's done in the early stages, when the workspace is empty. So an empty workspace is copied in, and any values aren't updated correctly. This fixes that (I've tested it myself in VS Code, with some adjustments).

To get this to work with the VSCode extension though, you'll need to go to editor.ts and replace all of the `document.uri.toString()` calls with `document.uri.toString().replace("%3A", ":")`. I think that in the context of `vscode.TextDocument`, it encodes `:` as `%3A` (which differs from how every other document URI uses colons in the Language Server). And so the URI will look something like `file:///c%3A/whatever/else/` while the LanguageServer stores it as `file:///c:/whatever/else/`. Relevant pull request: https://github.com/YarnSpinnerTool/VSCodeExtension/pull/10

Once you run the VSCode extension, you'll need to open a project folder (the extension will only allow the node editor once it has a project folder, I think). Then, open a yarn file. Then you can click "Show Graph" and it should work.

For repeat tests or for testing of commands, you need to close the graph editor and re-open it. The Graph Editor doesn't automatically refresh when VSCode automatically opens it or when you make changes.